### PR TITLE
Snyk-scan: dytt image til github registry

### DIFF
--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -36,7 +36,7 @@ jobs:
       with:
         registry: ${{ env.GITHUB_REGISTRY }}
         username: ${{ github.actor }}
-        password: ${{ secrets.GITHUB_TOKEN }}
+        password: ${{ github.token }}
     - name: Prepare tags
       id: docker_meta
       uses: docker/metadata-action@v5.5.1

--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -37,6 +37,7 @@ jobs:
         registry: ${{ env.GITHUB_REGISTRY }}
         username: ${{ github.actor }}
         password: ${{ github.token }}
+        logout: false
     - name: Prepare tags
       id: docker_meta
       uses: docker/metadata-action@v5.5.1

--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -54,7 +54,7 @@ jobs:
         context: ./${{ matrix.config.name }}/.
         file: ./${{ matrix.config.name }}/Dockerfile
         push: true
-        tags: ${{ steps.docker_meta.outputs.tags }}
+        tags: ${{ env.GITHUB_REGISTRY }}/${{ steps.docker_meta.outputs.tags }}
         labels: ${{ steps.docker_meta.outputs.labels }}
         cache-from: type=gha
         cache-to: type=gha,mode=max

--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -11,6 +11,7 @@ on:
 
 permissions:
   contents: read
+  packages: write
 
 jobs:
   snyk:

--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -46,7 +46,8 @@ jobs:
           type=ref,event=pr
           type=schedule,pattern=weekly
           type=semver,pattern={{version}}
-
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3.6.1
     - name: Build docker image
       uses: docker/build-push-action@v6.9.0
       with:

--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -19,6 +19,8 @@ jobs:
       security-events: write # for github/codeql-action/upload-sarif to upload SARIF results
       actions: read # only required for a private repository by github/codeql-action/upload-sarif to get the Action run status 
     runs-on: ubuntu-latest
+    env:
+      GITHUB_REGISTRY: ghcr.io
     strategy:
         fail-fast: false
         matrix:
@@ -28,15 +30,31 @@ jobs:
     name: ${{ matrix.config.name }}
     steps:
     - uses: actions/checkout@v4
-    - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3.6.1
+    - name: Log in to the Container registry 📦
+      uses: docker/login-action@v3.3.0
+      with:
+        registry: ${{ env.GITHUB_REGISTRY }}
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+    - name: Prepare tags
+      id: docker_meta
+      uses: docker/metadata-action@v5.5.1
+      with:
+        images: rapporteket/${{ matrix.config.name }}
+        tags: |
+          type=ref,event=branch
+          type=ref,event=pr
+          type=schedule,pattern=weekly
+          type=semver,pattern={{version}}
+
     - name: Build docker image
       uses: docker/build-push-action@v6.9.0
       with:
         context: ./${{ matrix.config.name }}/.
         file: ./${{ matrix.config.name }}/Dockerfile
-        push: false
-        tags: rapporteket/${{ matrix.config.name }}
+        push: true
+        tags: ${{ steps.docker_meta.outputs.tags }}
+        labels: ${{ steps.docker_meta.outputs.labels }}
         cache-from: type=gha
         cache-to: type=gha,mode=max
     - name: Run Snyk to check Docker image for vulnerabilities
@@ -47,7 +65,7 @@ jobs:
       env:
         SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
       with:
-        image: rapporteket/${{ matrix.config.name }}
+        image: ${{ env.GITHUB_REGISTRY }}/${{ steps.docker_meta.outputs.tags }}
         args: --file=${{ matrix.config.name }}/Dockerfile --severity-threshold=critical
     - name: Upload result to GitHub Code Scanning
       uses: github/codeql-action/upload-sarif@v3
@@ -60,7 +78,7 @@ jobs:
         SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
       with:
         command: monitor
-        image: rapporteket/${{ matrix.config.name }}
+        image: ${{ env.GITHUB_REGISTRY }}/${{ steps.docker_meta.outputs.tags }}
         args: --file=${{ matrix.config.name }}/Dockerfile --severity-threshold=critical --org=b034af62-43be-40c7-95e8-fdc56d6f3092
     - name: Accept only vulnerability levels below critical 
       continue-on-error: false
@@ -68,5 +86,5 @@ jobs:
       env:
         SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
       with:
-        image: rapporteket/${{ matrix.config.name }}
+        image: ${{ env.GITHUB_REGISTRY }}/${{ steps.docker_meta.outputs.tags }}
         args: --file=${{ matrix.config.name }}/Dockerfile --severity-threshold=critical

--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -4,24 +4,13 @@ on:
   push:
     branches: [ "main" ]
   pull_request:
-    # The branches below must be a subset of the branches above
     branches: [ "main" ]
   schedule:
     - cron: '30 22 * * 5'
 
-permissions:
-  contents: read
-  packages: write
-
 jobs:
   snyk:
-    permissions:
-      contents: read # for actions/checkout to fetch code
-      security-events: write # for github/codeql-action/upload-sarif to upload SARIF results
-      actions: read # only required for a private repository by github/codeql-action/upload-sarif to get the Action run status 
     runs-on: ubuntu-latest
-    env:
-      GITHUB_REGISTRY: ghcr.io
     strategy:
         fail-fast: false
         matrix:
@@ -34,10 +23,8 @@ jobs:
     - name: Log in to the Container registry 📦
       uses: docker/login-action@v3.3.0
       with:
-        registry: ${{ env.GITHUB_REGISTRY }}
-        username: ${{ github.actor }}
-        password: ${{ secrets.GHCR_TOKEN }}
-        logout: false
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
     - name: Prepare tags
       id: docker_meta
       uses: docker/metadata-action@v5.5.1
@@ -56,7 +43,7 @@ jobs:
         context: ./${{ matrix.config.name }}/.
         file: ./${{ matrix.config.name }}/Dockerfile
         push: true
-        tags: ${{ env.GITHUB_REGISTRY }}/${{ steps.docker_meta.outputs.tags }}
+        tags: ${{ steps.docker_meta.outputs.tags }}
         cache-from: type=gha
         cache-to: type=gha,mode=max
     - name: Run Snyk to check Docker image for vulnerabilities
@@ -67,7 +54,7 @@ jobs:
       env:
         SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
       with:
-        image: ${{ env.GITHUB_REGISTRY }}/${{ steps.docker_meta.outputs.tags }}
+        image: ${{ steps.docker_meta.outputs.tags }}
         args: --file=${{ matrix.config.name }}/Dockerfile --severity-threshold=critical
     - name: Upload result to GitHub Code Scanning
       uses: github/codeql-action/upload-sarif@v3
@@ -80,7 +67,7 @@ jobs:
         SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
       with:
         command: monitor
-        image: ${{ env.GITHUB_REGISTRY }}/${{ steps.docker_meta.outputs.tags }}
+        image: ${{ steps.docker_meta.outputs.tags }}
         args: --file=${{ matrix.config.name }}/Dockerfile --severity-threshold=critical --org=b034af62-43be-40c7-95e8-fdc56d6f3092
     - name: Accept only vulnerability levels below critical 
       continue-on-error: false
@@ -88,5 +75,5 @@ jobs:
       env:
         SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
       with:
-        image: ${{ env.GITHUB_REGISTRY }}/${{ steps.docker_meta.outputs.tags }}
+        image: ${{ steps.docker_meta.outputs.tags }}
         args: --file=${{ matrix.config.name }}/Dockerfile --severity-threshold=critical

--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -55,7 +55,6 @@ jobs:
         file: ./${{ matrix.config.name }}/Dockerfile
         push: true
         tags: ${{ env.GITHUB_REGISTRY }}/${{ steps.docker_meta.outputs.tags }}
-        labels: ${{ steps.docker_meta.outputs.labels }}
         cache-from: type=gha
         cache-to: type=gha,mode=max
     - name: Run Snyk to check Docker image for vulnerabilities

--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -36,7 +36,7 @@ jobs:
       with:
         registry: ${{ env.GITHUB_REGISTRY }}
         username: ${{ github.actor }}
-        password: ${{ github.token }}
+        password: ${{ secrets.GHCR_TOKEN }}
         logout: false
     - name: Prepare tags
       id: docker_meta


### PR DESCRIPTION
Snyk må ha et image å hente ned for å scanne det. Ellers henter Snyk bare gammelt image fra docker-hub. Fikses ved å først dytte image til github sitt docker registry, og så hente ned igjen for scanning.