### PR TITLE
Bruk eldre versjon av rocker/verse, fra v4.4.1 til v4.3.3

### DIFF
--- a/dev/Dockerfile
+++ b/dev/Dockerfile
@@ -1,4 +1,4 @@
-FROM rocker/verse:4.4.1
+FROM rocker/verse:4.3.3
 
 LABEL maintainer "Arnfinn Hykkerud Steindal <arnfinn.hykkerud.steindal@helse-nord.no>"
 


### PR DESCRIPTION
Bygde ikke lenger ukentlig. Fikk ikke til å bygge lokalt med v4.4.0 eller v4.4.1. Problemer med shiny_server-installasjonsskript.