### PR TITLE
base-r: installer xkeyval

### DIFF
--- a/base-r/Dockerfile
+++ b/base-r/Dockerfile
@@ -88,6 +88,7 @@ RUN tlmgr update --self && tlmgr install \
         ucs \
         uniquecounter \
         xcolor \
+        xkeyval \
         zapfding
 
 CMD ["R"]


### PR DESCRIPTION
LaTeX-pakke som trengtes av Ablanor