### PR TITLE
Kjøre bygging av image sekvensielt når cron-jobb

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -43,6 +43,7 @@ jobs:
       fail-fast: false
       matrix:
         image: ${{ fromJSON(needs.changes.outputs.images) }}
+      max-parallel: ${{ github.event_name == 'schedule' && 1 || 4 }}
     name: ${{ matrix.image }}
     steps:
       - name: Check out the repo


### PR DESCRIPTION
Gjøre det slik for å unngå at image basert på dev ikke får siste versjon av dev-image. Tidligere ble forrige ukes dev-image brukt når man bygde ukas registerspesifikke dev-image.

Closes #149