### PR TITLE
Bygg med GITHUB_PAT som miljøvariabel

### DIFF
--- a/base-r/Dockerfile
+++ b/base-r/Dockerfile
@@ -2,6 +2,9 @@ FROM rocker/r-ver:4.5.2
 
 LABEL maintainer="Arnfinn Hykkerud Steindal <arnfinn.hykkerud.steindal@helse-nord.no>"
 
+ARG GITHUB_PAT=
+ENV GITHUB_PAT=${GITHUB_PAT}
+
 # hadolint ignore=DL3008
 RUN apt-get update && apt-get install -y --no-install-recommends \
 # install gnupg2 to get latest version, to fix CVE-2025-68973. rm later if not needed.

--- a/dev/Dockerfile
+++ b/dev/Dockerfile
@@ -40,6 +40,10 @@ ENV TZ=Europe/Oslo
 # making proxy def (and other env vars) go all the way into Rstudio
 # console, based on
 # https://github.com/rocker-org/rocker-versioned/issues/91
+
+ARG GITHUB_PAT=
+ENV GITHUB_PAT=${GITHUB_PAT}
+
 ARG USERID=
 ENV USERID=${USERID}
 

--- a/ltmv-dev/Dockerfile
+++ b/ltmv-dev/Dockerfile
@@ -2,7 +2,7 @@ FROM rapporteket/dev:weekly
 
 LABEL maintainer="Arnfinn Hykkerud Steindal <arnfinn.hykkerud.steindal@helse-nord.no>"
 
-ARG GH_PAT
-ENV GITHUB_PAT=${GH_PAT}
+ARG GITHUB_PAT=
+ENV GITHUB_PAT=${GITHUB_PAT}
 
 RUN R -e "remotes::install_github('Rapporteket/ltmv', dependencies = TRUE)"

--- a/noric-dev/Dockerfile
+++ b/noric-dev/Dockerfile
@@ -2,6 +2,9 @@ FROM rapporteket/dev:weekly
 
 LABEL maintainer="Arnfinn Hykkerud Steindal <arnfinn.hykkerud.steindal@helse-nord.no>"
 
+ARG GITHUB_PAT=
+ENV GITHUB_PAT=${GITHUB_PAT}
+
 # add registry dev config and R pkg dependencies
 COPY --chown=rstudio:rstudio db.yml /home/rstudio/rap_config/
 COPY --chown=rstudio:rstudio rapbase.yml /home/rstudio/rap_config/

--- a/smerte-dev/Dockerfile
+++ b/smerte-dev/Dockerfile
@@ -2,6 +2,9 @@ FROM rapporteket/dev:weekly
 
 LABEL maintainer="Kevin Thon <kevin.otto.thon@helse-nord.no>"
 
+ARG GITHUB_PAT=
+ENV GITHUB_PAT=${GITHUB_PAT}
+
 # hadolint ignore=DL3008
 
 # add registry dev config and R pkg dependencies

--- a/traume-dev/Dockerfile
+++ b/traume-dev/Dockerfile
@@ -2,7 +2,7 @@ FROM rapporteket/dev:weekly
 
 LABEL maintainer="Arnfinn Hykkerud Steindal <arnfinn.hykkerud.steindal@helse-nord.no>"
 
-ARG GH_PAT
-ENV GITHUB_PAT=${GH_PAT}
+ARG GITHUB_PAT=
+ENV GITHUB_PAT=${GITHUB_PAT}
 
 RUN R -e "remotes::install_github('Rapporteket/traume', dependencies = TRUE)"


### PR DESCRIPTION
Bygging av rapbase og andre pakker fra github kunne feile pga. begrensing i antall api-kall til github. Fikses ved å bruke GITHUB_PAT.