### PR TITLE
base-r-alpine: oppdater Pandoc fra 2.19.2 til 3.10

### DIFF
--- a/base-r-alpine/Dockerfile
+++ b/base-r-alpine/Dockerfile
@@ -34,9 +34,9 @@ RUN installr -d \
            remotes \
            Cairo \
   && R -e "remotes::install_github('Rapporteket/rapbase')" \
-  && wget -q https://github.com/jgm/pandoc/releases/download/2.19.2/pandoc-2.19.2-linux-${TARGETARCH}.tar.gz \
-  && tar xzf pandoc-2.19.2-linux-${TARGETARCH}.tar.gz \
-  && mv pandoc-2.19.2/bin/* /usr/local/bin/ \
-  && rm -rf pandoc-2.19.2*
+  && wget -q https://github.com/jgm/pandoc/releases/download/3.10/pandoc-3.10-linux-${TARGETARCH}.tar.gz \
+  && tar xzf pandoc-3.10-linux-${TARGETARCH}.tar.gz \
+  && mv pandoc-3.10/bin/* /usr/local/bin/ \
+  && rm -rf pandoc-3.10*
 
 CMD ["R"]


### PR DESCRIPTION
Image går fra 600 MB til 700 MB.