### PR TITLE
Hent pandoc binary direkte fra pandoc image

### DIFF
--- a/base-r-alpine/Dockerfile
+++ b/base-r-alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM pandoc/minimal:latest AS pandoc-source
+FROM pandoc/minimal:3.10.0 AS pandoc-source
 
 FROM rhub/r-minimal:4.6.0
 

--- a/base-r-alpine/Dockerfile
+++ b/base-r-alpine/Dockerfile
@@ -1,8 +1,10 @@
+FROM pandoc/minimal:latest AS pandoc-source
+
 FROM rhub/r-minimal:4.6.0
 
 LABEL maintainer="Arnfinn Hykkerud Steindal <arnfinn.hykkerud.steindal@helse-nord.no>"
 
-COPY --from=pandoc/minimal:latest /usr/local/bin/pandoc /usr/local/bin/pandoc
+COPY --from=pandoc-source /usr/local/bin/pandoc /usr/local/bin/pandoc
 
 ENV LC_ALL=nb_NO.UTF-8
 ENV LANG=nb_NO.UTF-8

--- a/base-r-alpine/Dockerfile
+++ b/base-r-alpine/Dockerfile
@@ -2,6 +2,8 @@ FROM rhub/r-minimal:4.6.0
 
 LABEL maintainer="Arnfinn Hykkerud Steindal <arnfinn.hykkerud.steindal@helse-nord.no>"
 
+COPY --from=pandoc/minimal:latest /usr/local/bin/pandoc /usr/local/bin/pandoc
+
 ENV LC_ALL=nb_NO.UTF-8
 ENV LANG=nb_NO.UTF-8
 
@@ -33,10 +35,6 @@ RUN installr -d \
            ggplot2 \
            remotes \
            Cairo \
-  && R -e "remotes::install_github('Rapporteket/rapbase')" \
-  && wget -q https://github.com/jgm/pandoc/releases/download/2.19.2/pandoc-2.19.2-linux-${TARGETARCH}.tar.gz \
-  && tar xzf pandoc-2.19.2-linux-${TARGETARCH}.tar.gz \
-  && mv pandoc-2.19.2/bin/* /usr/local/bin/ \
-  && rm -rf pandoc-2.19.2*
+  && R -e "remotes::install_github('Rapporteket/rapbase')"
 
 CMD ["R"]


### PR DESCRIPTION
Binary har en størrelse på 148 MB. Image blir da på 677 MB for pandoc 3.10. Pandoc 3.10 på gamlemåten tar 701 MB.