### PR TITLE
Dytt til main under ukentlig bygg

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -57,6 +57,7 @@ jobs:
             type=ref,event=branch
             type=ref,event=pr
             type=schedule,pattern=weekly
+            type=schedule,pattern=main
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
       - name: Login to DockerHub

--- a/.github/workflows/multi-platform.yml
+++ b/.github/workflows/multi-platform.yml
@@ -50,6 +50,7 @@ jobs:
       meta-tags: |
         type=ref,event=branch
         type=schedule,pattern=weekly
+        type=schedule,pattern=main
         type=semver,pattern={{major}}.{{minor}}.{{patch}}
     secrets:
       registry-auths: |


### PR DESCRIPTION
For å få en main som inneholder de siste oppdateringene av pakker etc. weekly-tag vil ikke inneholde de endringene som er skjedd etter søndag, men det vil main-tag.

Closes #209