### PR TITLE
docker/github-builder: Send inn GITHUB_TOKEN som build-args

### DIFF
--- a/.github/workflows/multi-platform.yml
+++ b/.github/workflows/multi-platform.yml
@@ -37,8 +37,6 @@ jobs:
           - {name: rstudio}
     name: Push ${{ matrix.config.name }} image to docker hub
     uses: docker/github-builder/.github/workflows/build.yml@v1
-    env:
-      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
     permissions:
       contents: read
       id-token: write
@@ -48,7 +46,7 @@ jobs:
       platforms: linux/amd64,linux/arm64
       context: ./${{ matrix.config.name }}/.
       cache: true
-      build-args: GITHUB_PAT=${{ GITHUB_PAT }}
+      build-args: GITHUB_PAT=${{ github.token }}
       meta-images: rapporteket/${{ matrix.config.name }}
       meta-tags: |
         type=ref,event=branch

--- a/.github/workflows/multi-platform.yml
+++ b/.github/workflows/multi-platform.yml
@@ -37,6 +37,8 @@ jobs:
           - {name: rstudio}
     name: Push ${{ matrix.config.name }} image to docker hub
     uses: docker/github-builder/.github/workflows/build.yml@v1
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
     permissions:
       contents: read
       id-token: write
@@ -46,7 +48,7 @@ jobs:
       platforms: linux/amd64,linux/arm64
       context: ./${{ matrix.config.name }}/.
       cache: true
-      build-args: GITHUB_PAT=${{ secrets.GITHUB_TOKEN }}
+      build-args: GITHUB_PAT=${{ GITHUB_PAT }}
       meta-images: rapporteket/${{ matrix.config.name }}
       meta-tags: |
         type=ref,event=branch

--- a/.github/workflows/multi-platform.yml
+++ b/.github/workflows/multi-platform.yml
@@ -46,6 +46,7 @@ jobs:
       platforms: linux/amd64,linux/arm64
       context: ./${{ matrix.config.name }}/.
       cache: true
+      build-args: GITHUB_PAT=${{ secrets.GITHUB_TOKEN }}
       meta-images: rapporteket/${{ matrix.config.name }}
       meta-tags: |
         type=ref,event=branch

--- a/base-r-alpine/Dockerfile
+++ b/base-r-alpine/Dockerfile
@@ -10,9 +10,9 @@ ENV LC_ALL=nb_NO.UTF-8
 ENV LANG=nb_NO.UTF-8
 
 ARG TARGETARCH
+ARG GITHUB_PAT
 
-RUN --mount=type=secret,id=github_pat,env=GITHUB_PAT \
-     installr -d \
+RUN installr -d \
      -t "cmake libuv-dev icu-dev libpng-dev fontconfig-dev freetype-dev fribidi-dev harfbuzz-dev libxml2-dev libx11-dev mariadb-dev curl-dev git cairo-dev" \
      -a "mariadb-connector-c-dev libuv fontconfig harfbuzz fribidi libxml2 cairo harfbuzz-icu font-liberation mariadb-client" \
            bookdown \

--- a/base-r/Dockerfile
+++ b/base-r/Dockerfile
@@ -2,6 +2,8 @@ FROM rocker/r-ver:4.6.1
 
 LABEL maintainer="Arnfinn Hykkerud Steindal <arnfinn.hykkerud.steindal@helse-nord.no>"
 
+ARG GITHUB_PAT
+
 # hadolint ignore=DL3008
 RUN apt-get update && apt-get install -y --no-install-recommends \
 # install linux-libc-dev to get latest version, to fix critical CVE. rm later if not needed.
@@ -31,8 +33,7 @@ ENV TZ=Europe/Oslo
 
 # install R package dependencies and TinyTeX
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
-RUN --mount=type=secret,id=github_pat,env=GITHUB_PAT \
-    install2.r --error --skipinstalled --ncpus -1 \
+RUN install2.r --error --skipinstalled --ncpus -1 \
     remotes \
     && R -e "remotes::install_github('rapporteket/rapbase@*release')"\
     && rm -rf /tmp/downloaded_packages \ 

--- a/rstudio/Dockerfile
+++ b/rstudio/Dockerfile
@@ -51,10 +51,11 @@ RUN mkdir -p ${CONFIG_PATH} \
 # add rstudio user to root group  and enable shiny server
 ENV ROOT=TRUE
 
+ARG GITHUB_PAT
+
 ## provide users rstudio and shiny with corresponding environmental settings, install and config
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
-RUN --mount=type=secret,id=github_pat,env=GITHUB_PAT \
-    R -e "install.packages(c('remotes', 'lifecycle', 'testthat', 'lintr'), repos='https://cloud.r-project.org/')" \
+RUN R -e "install.packages(c('remotes', 'lifecycle', 'testthat', 'lintr'), repos='https://cloud.r-project.org/')" \
     && R -e "remotes::install_github('rapporteket/rapbase@*release', dependencies = TRUE)" \
     && R -e "file.copy(system.file(c('rapbaseConfig.yml'), package = 'rapbase'), Sys.getenv('R_RAP_CONFIG_PATH'))" \
     && chown rstudio:rstudio ${CONFIG_PATH}/* \


### PR DESCRIPTION
secrets er ikke støttet enda. Bygg feiler. Uansett ikke token som finnes etter bygging.